### PR TITLE
Disappearing Keys Fixed

### DIFF
--- a/Assets/Scripts/BlankKey.cs
+++ b/Assets/Scripts/BlankKey.cs
@@ -16,18 +16,18 @@ public class BlankKey : Key {
 		this.defaultColor = Color.black;
 	}
 
-	new void OnMouseUp() {}
+	protected override void OnMouseUp() {}
 
 	public override void SetAvailability(bool a) {
-		this.available = a;
-		if (a) {
-			StartCoroutine(MoveToLocalPoint(AVAIL_POSITION));
-		} else if (!this.pressed) {
-			StartCoroutine(MoveToLocalPoint(UNAVAIL_POSITION));
-		} 
+		// this.available = a;
+		// if (a) {
+		// 	StartCoroutine(MoveToLocalPoint(AVAIL_POSITION));
+		// } else if (!this.pressed) {
+		// 	StartCoroutine(MoveToLocalPoint(UNAVAIL_POSITION));
+		// } 
 	}
 
-	new public void Release() {}
+	public override void Release() {}
 
 	public override void SetValue(char c) {
 		this.val = c;

--- a/Assets/Scripts/ExitButton.cs
+++ b/Assets/Scripts/ExitButton.cs
@@ -61,6 +61,8 @@ public class ExitButton : MonoBehaviour {
 			this.character.transform.localScale = this.playerHead.localScale;
 			Hint.ClearHint();
 			this.controller.GetComponent<ZoomToTablet>().enabled = true;
+			FindUtilities.TryFind(transform.parent.gameObject, "SubmitButton")
+				.GetComponent<BoxCollider>().enabled = false;
 		}
 	}
 

--- a/Assets/Scripts/Key.cs
+++ b/Assets/Scripts/Key.cs
@@ -30,11 +30,7 @@ public class Key : MonoBehaviour {
 		this.available = true;
 	}
 
-	protected virtual void Start() {
-//		this.AVAIL_POSITION = transform.localPosition;
-//		this.UNAVAIL_POSITION = transform.localPosition;
-		UNAVAIL_POSITION.z += 0.03f;
-	}
+	protected virtual void Start() {}
 
 	public void AssignAvailPosition() {
 		this.AVAIL_POSITION = transform.localPosition;
@@ -42,6 +38,7 @@ public class Key : MonoBehaviour {
 
 	public void AssignUnavailPosition() {
 		this.UNAVAIL_POSITION = transform.localPosition;
+		this.UNAVAIL_POSITION.z += 0.03f;
 	}
 
 	public Vector3 GetAVAIL() {
@@ -126,11 +123,11 @@ public class Key : MonoBehaviour {
 	public virtual void SetAvailability(bool a) {
 		this.available = a;
 		if (a) {
-			StartCoroutine(MoveToLocalPoint(AVAIL_POSITION));
+			SendKeyToLocal(AVAIL_POSITION);
 			this.myMeshRenderer.material.color = ColorUtilities.AVAILABLE;
 		} else if (!this.pressed) {
 			this.myMeshRenderer.material.color = Color.black;
-			StartCoroutine(MoveToLocalPoint(UNAVAIL_POSITION));
+			SendKeyToLocal(UNAVAIL_POSITION);
 		} 
 	}
 
@@ -141,7 +138,7 @@ public class Key : MonoBehaviour {
 		downNeighbor = down;
 	}
 
-	public void Release() {
+	public virtual void Release() {
 		this.pressed = false;
 	}
 
@@ -156,7 +153,7 @@ public class Key : MonoBehaviour {
 			p.AddToCurrentString(this.val);
 			this.pressed = true;
 			this.myMeshRenderer.material.color = ColorUtilities.PRESSED; //Color.magenta;
-			StartCoroutine(MoveToLocalPoint(UNAVAIL_POSITION));
+			SendKeyToLocal(UNAVAIL_POSITION);
 			p.DetermineAvailability(this);
 		} else {
 			Debug.Log("This key is not available.");

--- a/Assets/Scripts/PlayerInventory.cs
+++ b/Assets/Scripts/PlayerInventory.cs
@@ -57,6 +57,10 @@ public class PlayerInventory : MonoBehaviour {
 		if (MyTablet != null) {
 			MyTablet.transform.localPosition = new Vector3(0f, 0.35f, 0.8f);
 			TabletPuzzle.SetEnabledKeys(true);
+			FindUtilities.TryFind(MyTablet, "SubmitButton")
+				.GetComponent<TabletSubmitButton>()
+				.SetBoxColliderEnabled(true);
+			Debug.Log("Tablet Submit collider enabled");
 		}
 	}
 
@@ -66,6 +70,10 @@ public class PlayerInventory : MonoBehaviour {
 			MyTablet.transform.localEulerAngles = new Vector3(0f, 0f, 0f);
 			MyTablet.transform.localScale = new Vector3(0.4f, 0.4f, 0.4f);
 			TabletPuzzle.SetEnabledKeys(false);
+			FindUtilities.TryFind(MyTablet, "SubmitButton")
+				.GetComponent<TabletSubmitButton>()
+				.SetBoxColliderEnabled(false);
+			Debug.Log("Tablet Submit collider disabled");
 		}
 	}
 
@@ -76,6 +84,10 @@ public class PlayerInventory : MonoBehaviour {
 			copy.y = -0.3f;
 			MyTablet.transform.localPosition = copy;
 			TabletPuzzle.SetEnabledKeys(false);
+			FindUtilities.TryFind(MyTablet, "SubmitButton")
+				.GetComponent<TabletSubmitButton>()
+				.SetBoxColliderEnabled(false);
+			Debug.Log("Tablet Submit collider disabled");
 		}
 	}
 
@@ -85,6 +97,10 @@ public class PlayerInventory : MonoBehaviour {
 			copy.x = 0f;
 			copy.y = 0f;
 			MyTablet.transform.localPosition = copy;
+			FindUtilities.TryFind(MyTablet, "SubmitButton")
+				.GetComponent<TabletSubmitButton>()
+				.SetBoxColliderEnabled(true);
+			Debug.Log("Tablet Submit collider enabled");
 		}
 	}
 

--- a/Assets/Scripts/SubmitButton.cs
+++ b/Assets/Scripts/SubmitButton.cs
@@ -11,6 +11,7 @@ public class SubmitButton : MonoBehaviour {
 		myPuzzle = FindUtilities.TryFind(
 			FindUtilities.TryFind(this.transform.parent.gameObject, "Pad"),
 			"Puzzle").GetComponent<Puzzle>();
+		GetComponent<BoxCollider>().enabled = false;
 	}
 	
 	protected virtual void OnMouseUp() {

--- a/Assets/Scripts/TabletPuzzle.cs
+++ b/Assets/Scripts/TabletPuzzle.cs
@@ -24,7 +24,8 @@ public class TabletPuzzle : Puzzle {
 		this.complete = true;
 		FindUtilities
 			.TryFind(this.transform.parent.gameObject, "SubmitButton")
-			.GetComponent<BoxCollider>().enabled = false;
+			.GetComponent<TabletSubmitButton>()
+			.SetBoxColliderEnabled(false);
 		this.RemoveDoor();
 		FindUtilities
 			.TryFind(this.transform.parent.gameObject, "Block")
@@ -37,6 +38,10 @@ public class TabletPuzzle : Puzzle {
 
 	protected override void ChangeWireChain() {
 		return;
+	}
+	
+	public override void Exit() {
+
 	}
 
 	public void RemovedFromDock() {

--- a/Assets/Scripts/TabletSubmitButton.cs
+++ b/Assets/Scripts/TabletSubmitButton.cs
@@ -6,11 +6,19 @@ public class TabletSubmitButton : SubmitButton {
 
 	private TabletPuzzle myTabletPuzzle;
 
+	void Awake() {
+		SetBoxColliderEnabled(false);
+	}
+
 	// Use this for initialization
 	protected override void Start () {
 		myTabletPuzzle = FindUtilities
 			.TryFind(this.transform.parent.gameObject, "Puzzle")
 			.GetComponent<TabletPuzzle>();
+	}
+
+	public void SetBoxColliderEnabled(bool setting) {
+		GetComponent<BoxCollider>().enabled = setting;
 	}
 
 	protected override void OnMouseUp() {

--- a/Assets/Scripts/ZoomToKeypad.cs
+++ b/Assets/Scripts/ZoomToKeypad.cs
@@ -52,6 +52,8 @@ public class ZoomToKeypad : MonoBehaviour {
 			GameObject keypad = other.gameObject.transform.parent.gameObject;
 			SavePlayerHeadTransform();
 			FindUtilities.TryFind(keypad.transform.parent.gameObject, "ExitButton").GetComponent<ExitButton>().SetPlayerHead(this.playerHead);
+			FindUtilities.TryFind(keypad.transform.parent.gameObject, "SubmitButton")
+				.GetComponent<BoxCollider>().enabled = true;
 			this.controller.GetComponent<FirstPersonController>().enabled = false;
 			Cursor.lockState = CursorLockMode.None;
 			Cursor.visible = true;
@@ -81,13 +83,11 @@ public class ZoomToKeypad : MonoBehaviour {
 			p.SetEnabledKeys(true);
 		} else if (other.tag == "Dock" && PlayerInventory.HasTablet()) {
 			this.controller.GetComponent<Rigidbody>().velocity = Vector3.zero;
-			Debug.Log("Placing tablet.");
 			PlayerInventory.PlaceTablet(other.gameObject.transform.parent);
 			other.gameObject.GetComponent<Dock>().ReturnTablet();
 		} else if (other.tag == "Tablet" && !PlayerInventory.HasTablet()) {
 			this.controller.GetComponent<Rigidbody>().velocity = Vector3.zero;
 			if (!PlayerInventory.HasTablet()) {
-				Debug.Log("Picking up tablet.");
 				FindUtilities
 					.TryFind(other.gameObject.transform.parent.parent.gameObject, "DockBlock")
 					.GetComponent<Dock>().TakeTablet();


### PR DESCRIPTION
Bug fixed. I did not see a real reason for submit buttons to be pressable before focusing on their puzzle. For this reason, I made it so submit buttons cannot be pressed out of turn. This prevents any bizarre behaviors arising from previously un-focused-upon puzzles losing tiles when their submit buttons are pressed at an incorrect time. I did this by disabling and enabling the submit button colliders when their puzzles lose or gain player focus, respectively.