### PR TITLE
Bugfix/pick up clicked detachables

### DIFF
--- a/Assets/Scripts/BoardMutator.cs
+++ b/Assets/Scripts/BoardMutator.cs
@@ -35,6 +35,8 @@ public class BoardMutator : MonoBehaviour {
 					DetachableKey dk = hit.collider.GetComponent<DetachableKey>();
 					if (!dk.IsPressed()) {
 						SwapKeys(dk.gameObject);
+					} else {
+						DropKey();
 					}
 				} else if (hit.collider.tag == "BlankKey") {
 					PutDownKey(hit.collider.gameObject);

--- a/Assets/Scripts/BoardMutator.cs
+++ b/Assets/Scripts/BoardMutator.cs
@@ -22,14 +22,20 @@ public class BoardMutator : MonoBehaviour {
 			mouseRay = Camera.main.ScreenPointToRay(Input.mousePosition);
 			if (Physics.Raycast(mouseRay, out hit, 2.0f)) {
 				if (hit.collider.tag == "DetachableKey") {
-					PickUpKey(hit.collider.gameObject);
+					DetachableKey dk = hit.collider.GetComponent<DetachableKey>();
+					if (!dk.IsPressed()) {
+						PickUpKey(dk.gameObject);
+					}
 				}
 			}
 		} else if (Input.GetMouseButtonUp(1)) {
 			mouseRay = Camera.main.ScreenPointToRay(Input.mousePosition);
 			if (Physics.Raycast(mouseRay, out hit, 2.0f)) {
 				if (hit.collider.tag == "DetachableKey") {
-					SwapKeys(hit.collider.gameObject);
+					DetachableKey dk = hit.collider.GetComponent<DetachableKey>();
+					if (!dk.IsPressed()) {
+						SwapKeys(dk.gameObject);
+					}
 				} else if (hit.collider.tag == "BlankKey") {
 					PutDownKey(hit.collider.gameObject);
 				} else {


### PR DESCRIPTION
This bug seemed pretty simple to fix and it was. The board mutator, responsible for (duh) mutating the board via the mouse, is now responsible for checking whether the detachable keys the player wants to interact with are pressed. This lets it abort swaps and key placements that are illegal by game rules. While nobody ever successfully used this to cheat, it was obviously a rather big problem.