### PR TITLE
bug fixed

### DIFF
--- a/Assets/Scenes/Friendship 2.unity
+++ b/Assets/Scenes/Friendship 2.unity
@@ -19692,7 +19692,8 @@ Prefab:
       propertyPath: m_MouseLook.YSensitivity
       value: 2
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 114200349412653058, guid: 7ebfdfb912aa6494aa29b61c3e2d1c20, type: 2}
   m_ParentPrefab: {fileID: 100100000, guid: 7ebfdfb912aa6494aa29b61c3e2d1c20, type: 2}
   m_IsPrefabParent: 0
 --- !u!20 &577167383 stripped

--- a/Assets/Scripts/Hint.cs
+++ b/Assets/Scripts/Hint.cs
@@ -20,7 +20,6 @@ public class Hint : MonoBehaviour {
 	}
 
 	public static void SetHint(string buildUp, string[] words) {
-		Debug.Log(words.Length);
 		Hint.buildUp = buildUp;
 		Hint.words = words;
 		display = new string[words.Length];
@@ -47,9 +46,8 @@ public class Hint : MonoBehaviour {
 	}
 
 	public static void ClearHint() {
-		Debug.Log("CLEAR");
-		words = null;
-		display = null;
+//		words = null;
+//		display = null;
 //		myText.text = "";
 		myCanvasText.text = "";
 		//myBackpane.GetComponent<MeshRenderer>().enabled = false;
@@ -57,10 +55,6 @@ public class Hint : MonoBehaviour {
 	}
 
 	public static void FoundWord(string word) {
-		if (words == null) {
-			RefreshDisplay();
-			return;
-		}
 		for(int i = 0; i < words.Length; i++) {
 			if (word == words[i]) {
 				display[i] = words[i];

--- a/Assets/Scripts/Puzzle.cs
+++ b/Assets/Scripts/Puzzle.cs
@@ -93,7 +93,8 @@ public class Puzzle : MonoBehaviour {
 				currentStringActual = "";
 				return false;
 			}
-			Hint.FoundWord(currentStringMesh.text);
+			Hint.FoundWord(currentStringActual);
+			FoundWord();
 			currentStringActual = "";
 			return true;
 		}

--- a/Assets/Scripts/SubmitButton.cs
+++ b/Assets/Scripts/SubmitButton.cs
@@ -20,7 +20,7 @@ public class SubmitButton : MonoBehaviour {
 		}
 		if (myPuzzle.TestSubmission()) {
 			myPuzzle.ConvertPressedDetachablesToVanilla();
-			myPuzzle.FoundWord();
+			//myPuzzle.FoundWord();
 			if (!myPuzzle.IsComplete()) {
 				this.myPuzzle.ReleaseAllKeys();
 			}


### PR DESCRIPTION
I got rid of the band-aid I made last night. Upon testing the game further this morning, I found that the band-aid did not really fix the problem even temporarily. Components were trying to use Hint methods after Hint's fields were being set to null. I am guessing these are calls to Hint methods that I did not expect. Since I am hiding the Hint text when you leave a puzzle, I decided to just not set any of these fields to null. They are reassigned as soon as you enter focus on another puzzle.